### PR TITLE
Fixing error that lead to 500 errors on the main page

### DIFF
--- a/p2pool/data.py
+++ b/p2pool/data.py
@@ -955,7 +955,7 @@ def get_warnings(tracker, best_share, net, bitcoind_getnetworkinfo, bitcoind_wor
             'An upgrade is likely necessary. Check http://p2pool.forre.st/ for more information.' % (
                 majority_desired_version, 100*desired_version_counts[majority_desired_version]/sum(desired_version_counts.itervalues())))
     
-    if bitcoind_getnetworkinfo['warnings'] != '':
+    if bitcoind_getnetworkinfo['warnings'] != '' and 'errors' in bitcoind_getnetworkinfo:
         if 'This is a pre-release test build' not in bitcoind_getnetworkinfo['errors']:
             res.append('(from bitcoind) %s' % (bitcoind_getnetworkinfo['errors'],))
     


### PR DESCRIPTION
There may be a more elegant solution, however this got me to a working p2pool page.  Otherwise the jQuery calls were failing with a 500 error and there were no hashrates or active miners shown on the p2pool page at http://public-ftc-p2pool-6e24aaba5ce31b6d.elb.us-east-1.amazonaws.com/static/